### PR TITLE
Continue on transformation Apply errors

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -83,7 +83,11 @@ func (c Controller) Execute(parentCtx context.Context) error {
 			default:
 				transformed, err := c.applyTransformations(req)
 				if err != nil {
-					return err
+					if !c.config.ContinueOnError {
+						return err
+					}
+					c.logger.Warn("unable to transform request %s: %w", req.String(), err)
+					continue
 				}
 				reqsChan <- transformed
 			}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -16,6 +16,7 @@ var testLogger = logging.Noop()
 
 func TestController(t *testing.T) {
 	req, err := requests.FromStr("http//localhost:4321/test?test=true", "GET")
+	require.NoError(t, err)
 
 	requestExecutor := NewMockRequestExecutor()
 
@@ -45,6 +46,7 @@ func TestController(t *testing.T) {
 
 func TestHttpRequestExecutor_ContinueOnErrorFalse(t *testing.T) {
 	req, err := requests.FromStr("http//localhost:4321/error", "GET")
+	require.NoError(t, err)
 
 	requestExecutor := NewMockRequestExecutor()
 
@@ -124,6 +126,7 @@ func TestHttpExecutor_TimeBudgetCompletion(t *testing.T) {
 
 func TestControllerWithTransformationErrorContinueOnError(t *testing.T) {
 	req, err := requests.FromStr("http//localhost:4321/test?test=true", "GET")
+	require.NoError(t, err)
 
 	requestExecutor := NewMockRequestExecutor()
 
@@ -151,6 +154,7 @@ func TestControllerWithTransformationErrorContinueOnError(t *testing.T) {
 
 func TestControllerWithTransformationError(t *testing.T) {
 	req, err := requests.FromStr("http//localhost:4321/test?test=true", "GET")
+	require.NoError(t, err)
 
 	requestExecutor := NewMockRequestExecutor()
 


### PR DESCRIPTION
Allow continuing cache preparatin in case of transformation errors, for example some apis may have missing parameters which are expected from transformations ( eg. `from`, `to` ...).